### PR TITLE
Remove lodash and improve code readability

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,5 @@
-#!/usr/bin/env node
-
 'use strict'
 
-// include dependencies
-var _ = require('lodash');
 var fs = require('fs');
 var path = require('path');
 var svgo = require('svgo');
@@ -26,47 +22,55 @@ module.exports = {
     generateJcons: function() {
         fs.readdir(sourceDir, function(error, files) {
             if (error) throw error;
+
             var generateOutputFile = function(outputObject) {
                 console.log('jcons: completed ' + outputDir + outputName + '.json');
+
                 mkdirp(outputDir, function(error) {
                     if (error) throw error;
+
                     jsonfile.writeFile(outputDir + outputName + '.json', outputObject, { spaces: outputSpaces }, function (error) {
                         if (error) throw error;
                     });
                 });
             };
-            var iconsObject     = {};
-            var totalIcons      = files.length;
-            var currentIcon     = 0;
-            _.each(files, function(fileName, index) {
-                // check for .svg extension
-                if(!_.endsWith(fileName, '.svg')) {
-                    totalIcons--;
+
+            var iconsObject = {};
+            var totalIcons = files.length;
+            var currentIcon = 0;
+
+            files.forEach(function(fileName, index) {
+
+                // skip file when the extension doesn't match
+                if (!path.extname(fileName) === '.svg') {
+                    totalIcons --;
                     return;
                 }
 
-                // remmeber icon name without extension
-                var iconKey = _.trimEnd(fileName, '.svg');
+                // remember icon name without extension
+                var iconKey = path.basename(filename, '.svg');
 
                 // read each file
-                fs.readFile(path.resolve(sourceDir + fileName), 'utf8', function(error, svgData) {
+                fs.readFile(path.resolve(sourceDir, fileName), 'utf8', function(error, svgData) {
                     if (error) throw error;
 
                     // optimize svg file
                     svgoGenerator.optimize(svgData, function(result) {
                         var svgString = result.data;
+
                         // add svg string to icons object
                         iconsObject[iconKey] = svgString;
 
                         // increment current icon to keep track of progress
-                        currentIcon++;
+                        currentIcon ++;
                         console.log('jcons: generated [' + currentIcon + '/' + totalIcons + '] ' + iconKey);
-                        if(currentIcon === totalIcons) generateOutputFile(iconsObject);
-                    });
 
+                        if (currentIcon === totalIcons) {
+                            generateOutputFile(iconsObject);
+                        }
+                    });
                 });
             });
-
         });
     }
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "fs": "0.0.2",
     "jsonfile": "^2.2.3",
-    "lodash": "^4.10.0",
     "mkdirp": "^0.5.1",
     "path": "^0.12.7",
     "svgo": "^0.6.4"


### PR DESCRIPTION
Replace lodash functions with Node's path functions:

```
_.each(files, ...
files.forEach(...
```

```
if(!_.endsWith(fileName, '.svg'))
if (!path.extname(fileName) === '.svg')
```

```
var iconKey = _.trimEnd(fileName, '.svg');
var iconKey = path.basename(filename, '.svg');
```
